### PR TITLE
feat: 인증, 인가 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/src/apis/useIsAuthenticated.ts
+++ b/src/apis/useIsAuthenticated.ts
@@ -1,0 +1,16 @@
+import { axiosInstance } from "@/lib/axiosInstance";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+interface ResponseMe {
+  isAuthorized: boolean;
+}
+
+export const useIsAuthorized = () => {
+  const { data } = useSuspenseQuery({
+    queryKey: ["me"],
+    queryFn: () => axiosInstance.get<ResponseMe>("/auth/me"),
+    select: (data) => data.data,
+  });
+
+  return data?.isAuthorized;
+};

--- a/src/apis/useSignout.ts
+++ b/src/apis/useSignout.ts
@@ -1,0 +1,15 @@
+import { axiosInstance } from "@/lib/axiosInstance";
+import { useMutation } from "@tanstack/react-query";
+
+const signout = async () => {
+  return axiosInstance.post("/auth/signout");
+};
+
+export const useSignout = () => {
+  return useMutation({
+    mutationFn: signout,
+    onSuccess: () => {
+      location.reload();
+    },
+  });
+};

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -1,4 +1,5 @@
 import { useIsAuthorized } from "@/apis/useIsAuthenticated";
+import { useSignout } from "@/apis/useSignout";
 import { HomeIcon, LogInIcon, LogOutIcon } from "lucide-react";
 import { Link } from "react-router-dom";
 
@@ -24,17 +25,27 @@ export const HeaderHome = () => (
   </Link>
 );
 
-const ProfileLogin = () => (
-  <Link to="/logout">
-    <LogOutIcon size={24} />
-  </Link>
-);
+const ProfileLogin = () => {
+  const { mutate: logout } = useSignout();
 
-const ProfileLogout = () => (
-  <Link to="/signin">
-    <LogInIcon size={24} />
-  </Link>
-);
+  const handleLogout = () => {
+    logout();
+  };
+
+  return (
+    <Link to="">
+      <LogOutIcon size={24} onClick={handleLogout} />
+    </Link>
+  );
+};
+
+const ProfileLogout = () => {
+  return (
+    <Link to="/signin">
+      <LogInIcon size={24} />
+    </Link>
+  );
+};
 
 export const HeaderProfile = () => {
   const isAuthorized = useIsAuthorized();

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -1,4 +1,5 @@
-import { HomeIcon } from "lucide-react";
+import { useIsAuthorized } from "@/apis/useIsAuthenticated";
+import { HomeIcon, LogInIcon, LogOutIcon } from "lucide-react";
 import { Link } from "react-router-dom";
 
 interface HeaderProps {
@@ -23,4 +24,21 @@ export const HeaderHome = () => (
   </Link>
 );
 
+const ProfileLogin = () => (
+  <Link to="/logout">
+    <LogOutIcon size={24} />
+  </Link>
+);
+
+const ProfileLogout = () => (
+  <Link to="/signin">
+    <LogInIcon size={24} />
+  </Link>
+);
+
+export const HeaderProfile = () => {
+  const isAuthorized = useIsAuthorized();
+
+  return isAuthorized ? <ProfileLogin /> : <ProfileLogout />;
+};
 export default Header;

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -6,3 +6,5 @@ export const axiosInstance = axios.create({
     "Content-Type": "application/json",
   },
 });
+
+axiosInstance.defaults.withCredentials = true;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,8 @@ import TanstackQueryProvider from "@/providers/tanstackQuery";
 import HomePage from "@/pages/Home";
 import DetailPage from "@/pages/Detail";
 import WritePage from "@/pages/Write";
+import Signup from "@/pages/Signup";
+import Signin from "@/pages/Signin";
 
 const router = createBrowserRouter([
   {
@@ -20,6 +22,14 @@ const router = createBrowserRouter([
   {
     path: "write/:id?",
     element: <WritePage />,
+  },
+  {
+    path: "/signup",
+    element: <Signup />,
+  },
+  {
+    path: "/signin",
+    element: <Signin />,
   },
 ]);
 

--- a/src/pages/Detail/apis/useDeleteThread.ts
+++ b/src/pages/Detail/apis/useDeleteThread.ts
@@ -11,7 +11,7 @@ export const useDeleteThread = (threadId: number, onSuccess?: () => void) => {
   return useMutation({
     mutationFn: () => deleteThread(threadId),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({
+      await queryClient.removeQueries({
         queryKey: ["thread", threadId],
       });
       onSuccess?.();

--- a/src/pages/Detail/apis/useDeleteThread.ts
+++ b/src/pages/Detail/apis/useDeleteThread.ts
@@ -12,7 +12,7 @@ export const useDeleteThread = (threadId: number, onSuccess?: () => void) => {
     mutationFn: () => deleteThread(threadId),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ["threads", threadId],
+        queryKey: ["thread", threadId],
       });
       onSuccess?.();
     },

--- a/src/pages/Detail/components/DetailCard.tsx
+++ b/src/pages/Detail/components/DetailCard.tsx
@@ -36,29 +36,7 @@ const DetailCard = () => {
         <CardHeader>
           <CardTitle className=" text-3xl">{title}</CardTitle>
           <div className="flex gap-4 justify-between w-full pt-4">
-            <p className="flex items-center">작성자: {author}</p>
-            <div className="flex">
-              <Dialog>
-                <DialogTrigger>
-                  <Button variant="link" className="w-fit">
-                    삭제
-                  </Button>
-                </DialogTrigger>
-                <DialogContent>
-                  <DialogHeader>
-                    <DialogDescription>
-                      정말로 삭제하시겠습니까?
-                    </DialogDescription>
-                  </DialogHeader>
-                  <Button onClick={handleDelete} variant="destructive">
-                    확인
-                  </Button>
-                </DialogContent>
-              </Dialog>
-              <Button variant="link" className="w-fit" onClick={handleUpdate}>
-                수정
-              </Button>
-            </div>
+            <p className="flex items-center">작성자: {author.name}</p>
           </div>
         </CardHeader>
         <CardContent>

--- a/src/pages/Detail/components/DetailCard.tsx
+++ b/src/pages/Detail/components/DetailCard.tsx
@@ -1,34 +1,13 @@
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  Dialog,
-  DialogDescription,
-  DialogHeader,
-  DialogTrigger,
-  DialogContent,
-} from "@/components/ui/dialog";
-import { useDeleteThread } from "@/pages/Detail/apis/useDeleteThread";
+import UpdateDeleteDialog from "@/pages/Detail/components/UpdateDeleteDialog";
 import { useFetchThread } from "@/pages/Home/apis/fetchThread";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
 const DetailCard = () => {
   const threadId = useParams().id as string;
-  const navigate = useNavigate();
-
   const {
-    data: { title, content, author },
+    data: { title, content, author, isMyThread },
   } = useFetchThread(Number(threadId));
-  const { mutate: deleteThread } = useDeleteThread(Number(threadId), () =>
-    navigate("/")
-  );
-
-  const handleDelete = () => {
-    deleteThread();
-  };
-
-  const handleUpdate = () => {
-    navigate(`/write/${threadId}`);
-  };
 
   return (
     <Card className="w-full p-8 flex ">
@@ -37,6 +16,7 @@ const DetailCard = () => {
           <CardTitle className=" text-3xl">{title}</CardTitle>
           <div className="flex gap-4 justify-between w-full pt-4">
             <p className="flex items-center">작성자: {author.name}</p>
+            {isMyThread && <UpdateDeleteDialog />}
           </div>
         </CardHeader>
         <CardContent>

--- a/src/pages/Detail/components/UpdateDeleteDialog.tsx
+++ b/src/pages/Detail/components/UpdateDeleteDialog.tsx
@@ -1,0 +1,53 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { useDeleteThread } from "@/pages/Detail/apis/useDeleteThread";
+import { useNavigate, useParams } from "react-router-dom";
+
+const UpdateDeleteDialog = () => {
+  const threadId = useParams().id as string;
+
+  const navigate = useNavigate();
+
+  const { mutate: deleteThread } = useDeleteThread(Number(threadId), () => {
+    navigate("/");
+  });
+
+  const handleDelete = () => {
+    deleteThread();
+  };
+
+  const handleUpdate = () => {
+    navigate(`/write/${threadId}`);
+  };
+
+  return (
+    <div className="flex">
+      <Dialog>
+        <DialogTrigger>
+          <Button variant="link" className="w-fit">
+            삭제
+          </Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogDescription>정말로 삭제하시겠습니까?</DialogDescription>
+          </DialogHeader>
+          <Button onClick={handleDelete} variant="destructive">
+            확인
+          </Button>
+        </DialogContent>
+      </Dialog>
+      <Button variant="link" className="w-fit" onClick={handleUpdate}>
+        수정
+      </Button>
+    </div>
+  );
+};
+
+export default UpdateDeleteDialog;

--- a/src/pages/Home/apis/fetchThread.ts
+++ b/src/pages/Home/apis/fetchThread.ts
@@ -1,14 +1,20 @@
 import { axiosInstance } from "@/lib/axiosInstance";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
-interface Thread {
+interface User {
+  id: number;
+  name: string;
+}
+
+interface ThreadResponse {
   id: number;
   title: string;
   content: string;
-  author: string;
+  author: User;
+  isMyThread: boolean;
 }
 
-const fetchThread = async (id: number): Promise<Thread> => {
+const fetchThread = async (id: number): Promise<ThreadResponse> => {
   const { data } = await axiosInstance.get(`/threads/${id}`);
   return data;
 };

--- a/src/pages/Home/apis/useFetchThreadList.ts
+++ b/src/pages/Home/apis/useFetchThreadList.ts
@@ -18,7 +18,7 @@ const fetchThreadList = (page: number) => {
 
 export const useFetchThreadList = (page: number) => {
   return useQuery({
-    queryKey: ["threads", page],
+    queryKey: ["thread", page],
     queryFn: () => fetchThreadList(page),
     placeholderData: keepPreviousData,
     select: (data) => data.data,

--- a/src/pages/Home/apis/usePostThread.ts
+++ b/src/pages/Home/apis/usePostThread.ts
@@ -34,7 +34,7 @@ export const usePostThread = ({
   return useMutation({
     mutationFn: postThread,
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["threads"] });
+      await queryClient.invalidateQueries({ queryKey: ["thread"] });
       handleSuccess?.();
     },
     onError: () => {

--- a/src/pages/Home/apis/usePostThread.ts
+++ b/src/pages/Home/apis/usePostThread.ts
@@ -4,7 +4,6 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 interface PostThreadRequest {
   title: string;
   content: string;
-  author: string;
 }
 
 interface PostThreadResponse {

--- a/src/pages/Home/apis/usePostThread.ts
+++ b/src/pages/Home/apis/usePostThread.ts
@@ -7,20 +7,38 @@ interface PostThreadRequest {
   author: string;
 }
 
+interface PostThreadResponse {
+  message: string;
+}
+
 const postThread = async (data: PostThreadRequest) => {
-  const response = await axiosInstance.post("threads", data);
+  const response = await axiosInstance.post<PostThreadResponse>(
+    "threads",
+    data
+  );
 
   return response.data;
 };
 
-export const usePostThread = (handleSuccess: () => void) => {
+interface UsePostThreadProps {
+  onSuccess?: () => void;
+  onError?: () => void;
+}
+
+export const usePostThread = ({
+  onSuccess: handleSuccess,
+  onError: handleError,
+}: UsePostThreadProps) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: postThread,
-    onSettled: async () => {
+    onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["threads"] });
-      handleSuccess();
+      handleSuccess?.();
+    },
+    onError: () => {
+      handleError?.();
     },
   });
 };

--- a/src/pages/Home/components/ThreadList.tsx
+++ b/src/pages/Home/components/ThreadList.tsx
@@ -19,11 +19,16 @@ const ThreadList = () => {
       {data?.data.map((thread) => (
         <ThreadItem key={thread.id} {...thread} />
       ))}
-      <Pagination
-        setPage={setPage}
-        page={page}
-        totalPage={data?.totalPage || 5}
-      />
+      {data?.data.length === 0 && (
+        <div className="text-center">Thread is Empty</div>
+      )}
+      {data && data.totalPage > 0 && (
+        <Pagination
+          setPage={setPage}
+          page={page}
+          totalPage={data?.totalPage ?? 5}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/Home/components/ThreadPostModal.tsx
+++ b/src/pages/Home/components/ThreadPostModal.tsx
@@ -23,7 +23,6 @@ const ThreadPostFormModal = ({
 
   const titleRef = useRef<HTMLInputElement>(null);
   const contentRef = useRef<HTMLTextAreaElement>(null);
-  const authorRef = useRef<HTMLInputElement>(null);
 
   const { mutate: postThread } = usePostThread({
     onSuccess: () => setOpen(false),
@@ -33,11 +32,7 @@ const ThreadPostFormModal = ({
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
 
-    if (
-      !titleRef.current?.value ||
-      !contentRef.current?.value ||
-      !authorRef.current?.value
-    ) {
+    if (!titleRef.current?.value || !contentRef.current?.value) {
       alert("모든 필드를 입력해주세요.");
       return;
     }
@@ -45,7 +40,6 @@ const ThreadPostFormModal = ({
     postThread({
       title: titleRef.current?.value,
       content: contentRef.current?.value,
-      author: authorRef.current?.value,
     });
   };
 
@@ -63,8 +57,6 @@ const ThreadPostFormModal = ({
           <Input id="title" type="text" ref={titleRef} />
           <Label htmlFor="content">내용</Label>
           <Textarea id="content" className="resize-none" ref={contentRef} />
-          <Label htmlFor="author">작성자</Label>
-          <Input id="author" type="text" ref={authorRef} />
           <Button type="submit">작성</Button>
         </form>
       </DialogContent>

--- a/src/pages/Home/components/ThreadPostModal.tsx
+++ b/src/pages/Home/components/ThreadPostModal.tsx
@@ -25,7 +25,10 @@ const ThreadPostFormModal = ({
   const contentRef = useRef<HTMLTextAreaElement>(null);
   const authorRef = useRef<HTMLInputElement>(null);
 
-  const { mutate: postThread } = usePostThread(() => setOpen(false));
+  const { mutate: postThread } = usePostThread({
+    onSuccess: () => setOpen(false),
+    onError: () => alert("로그인 후 이용해주세요."),
+  });
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,4 +1,4 @@
-import Header, { HeaderHome } from "@/components/ui/header";
+import Header, { HeaderHome, HeaderProfile } from "@/components/ui/header";
 import ThreadList from "@/pages/Home/components/ThreadList";
 import ThreadPostFormModal from "@/pages/Home/components/ThreadPostModal";
 import { Suspense } from "react";
@@ -6,7 +6,7 @@ import { Suspense } from "react";
 const HomePage = () => {
   return (
     <>
-      <Header left={<HeaderHome />} />
+      <Header left={<HeaderHome />} right={<HeaderProfile />} />
       <div className="p-8">
         <Suspense fallback={<div>Loading...</div>}>
           <ThreadList />

--- a/src/pages/Signin/apis/useSignin.ts
+++ b/src/pages/Signin/apis/useSignin.ts
@@ -1,0 +1,16 @@
+import { axiosInstance } from "@/lib/axiosInstance";
+import { useMutation } from "@tanstack/react-query";
+
+interface RequestSignin {
+  name: string;
+  password: string;
+}
+
+export const useSignin = (onSuccess: () => void) => {
+  return useMutation({
+    mutationFn: (data: RequestSignin) => {
+      return axiosInstance.post("/auth/signin", data);
+    },
+    onSuccess,
+  });
+};

--- a/src/pages/Signin/index.tsx
+++ b/src/pages/Signin/index.tsx
@@ -1,0 +1,49 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useSignin } from "@/pages/Signin/apis/useSignin";
+import { FormEvent, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+
+const Signin = () => {
+  const nameRef = useRef<HTMLInputElement>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
+
+  const navigate = useNavigate();
+
+  const { mutate: signin } = useSignin(() => navigate("/"));
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+
+    if (!nameRef.current?.value || !passwordRef.current?.value) {
+      alert("모든 필드를 입력해주세요.");
+      return;
+    }
+
+    signin({
+      name: nameRef.current?.value,
+      password: passwordRef.current?.value,
+    });
+  };
+
+  return (
+    <div className="flex justify-center items-center h-full w-full p-8">
+      <Card className="w-full">
+        <CardHeader>Sign in</CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            <Label htmlFor="name">닉네임</Label>
+            <Input ref={nameRef} id="name" type="text" />
+            <Label htmlFor="password">비밀번호</Label>
+            <Input ref={passwordRef} id="password" type="password" />
+            <Button type="submit">로그인</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default Signin;

--- a/src/pages/Signin/index.tsx
+++ b/src/pages/Signin/index.tsx
@@ -1,5 +1,10 @@
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useSignin } from "@/pages/Signin/apis/useSignin";
@@ -41,6 +46,11 @@ const Signin = () => {
             <Button type="submit">로그인</Button>
           </form>
         </CardContent>
+        <CardFooter>
+          <Button variant="link" onClick={() => navigate("/signup")}>
+            Sign up
+          </Button>
+        </CardFooter>
       </Card>
     </div>
   );

--- a/src/pages/Signin/index.tsx
+++ b/src/pages/Signin/index.tsx
@@ -8,7 +8,8 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useSignin } from "@/pages/Signin/apis/useSignin";
-import { FormEvent, useRef } from "react";
+import { FormEvent, useEffect, useRef } from "react";
+
 import { useNavigate } from "react-router-dom";
 
 const Signin = () => {
@@ -19,6 +20,35 @@ const Signin = () => {
 
   const { mutate: signin } = useSignin(() => navigate("/"));
 
+  const saveSharedPref = (prefKey: string, prefValue: string) => {
+    if (window.Android && window.Android.saveString) {
+      window.Android.saveString(prefKey, prefValue);
+    }
+
+    return null;
+  };
+
+  const loadSharedPref = (prefKey: string) => {
+    if (window.Android && window.Android.getString) {
+      return window.Android.getString(prefKey);
+    }
+
+    return null;
+  };
+
+  useEffect(() => {
+    const loadData = async () => {
+      const name = loadSharedPref("name");
+      const password = loadSharedPref("password");
+
+      if (name && password) {
+        signin({ name, password });
+      }
+    };
+
+    loadData();
+  }, [signin]);
+
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
 
@@ -26,6 +56,9 @@ const Signin = () => {
       alert("모든 필드를 입력해주세요.");
       return;
     }
+
+    saveSharedPref("name", nameRef.current?.value);
+    saveSharedPref("password", passwordRef.current?.value);
 
     signin({
       name: nameRef.current?.value,

--- a/src/pages/Signup/apis/useSignup.ts
+++ b/src/pages/Signup/apis/useSignup.ts
@@ -1,0 +1,16 @@
+import { axiosInstance } from "@/lib/axiosInstance";
+import { useMutation } from "@tanstack/react-query";
+
+interface RequestSignup {
+  name: string;
+  password: string;
+}
+
+export const useSignup = (onSuccess: () => void) => {
+  return useMutation({
+    mutationFn: (data: RequestSignup) => {
+      return axiosInstance.post("/auth/signup", data);
+    },
+    onSuccess,
+  });
+};

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -1,0 +1,57 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useSignup } from "@/pages/Signup/apis/useSignup";
+import { FormEvent, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+
+const Signup = () => {
+  const nameRef = useRef<HTMLInputElement>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
+  const checkPasswordRef = useRef<HTMLInputElement>(null);
+
+  const navigate = useNavigate();
+
+  const { mutate: signup } = useSignup(() => navigate("/signin"));
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+
+    if (
+      !nameRef.current?.value ||
+      !passwordRef.current?.value ||
+      !checkPasswordRef.current?.value
+    ) {
+      alert("모든 필드를 입력해주세요.");
+      return;
+    }
+
+    if (passwordRef.current?.value !== checkPasswordRef.current?.value) {
+      alert("비밀번호가 일치하지 않습니다.");
+      return;
+    }
+
+    signup({
+      name: nameRef.current?.value,
+      password: passwordRef.current?.value,
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>Sign up</CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit}>
+          <Label htmlFor="name">닉네임</Label>
+          <Input id="name" type="text" />
+          <Label htmlFor="password">비밀번호</Label>
+          <Input id="password" type="password" />
+          <Label htmlFor="checkPassword">비밀번호 확인</Label>
+          <Input id="checkPassword" type="password" />
+        </form>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default Signup;

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -1,4 +1,10 @@
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useSignup } from "@/pages/Signup/apis/useSignup";
@@ -38,19 +44,27 @@ const Signup = () => {
   };
 
   return (
-    <Card>
-      <CardHeader>Sign up</CardHeader>
-      <CardContent>
-        <form onSubmit={handleSubmit}>
-          <Label htmlFor="name">닉네임</Label>
-          <Input id="name" type="text" />
-          <Label htmlFor="password">비밀번호</Label>
-          <Input id="password" type="password" />
-          <Label htmlFor="checkPassword">비밀번호 확인</Label>
-          <Input id="checkPassword" type="password" />
-        </form>
-      </CardContent>
-    </Card>
+    <div className="flex justify-center items-center h-full w-full p-8">
+      <Card className="w-full">
+        <CardHeader>Sign up</CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            <Label htmlFor="name">닉네임</Label>
+            <Input ref={nameRef} id="name" type="text" />
+            <Label htmlFor="password">비밀번호</Label>
+            <Input ref={passwordRef} id="password" type="password" />
+            <Label htmlFor="checkPassword">비밀번호 확인</Label>
+            <Input ref={checkPasswordRef} id="checkPassword" type="password" />
+            <Button type="submit">회원가입</Button>
+          </form>
+        </CardContent>
+        <CardFooter>
+          <Button variant="link" onClick={() => navigate("/signin")}>
+            Sign in
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
   );
 };
 

--- a/src/pages/Write/apis/useUpdateThread.ts
+++ b/src/pages/Write/apis/useUpdateThread.ts
@@ -18,7 +18,7 @@ export const useUpdateThread = (threadId: number, onSuccess?: () => void) => {
     mutationFn: (data: RequestUpdateThread) => updateThread(threadId, data),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ["threads"],
+        queryKey: ["thread"],
       });
       onSuccess?.();
     },

--- a/src/pages/Write/apis/useUpdateThread.ts
+++ b/src/pages/Write/apis/useUpdateThread.ts
@@ -4,7 +4,6 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 interface RequestUpdateThread {
   title: string;
   content: string;
-  author: string;
 }
 
 const updateThread = async (threadId: number, data: RequestUpdateThread) => {

--- a/src/pages/Write/components/DetailFormCard.tsx
+++ b/src/pages/Write/components/DetailFormCard.tsx
@@ -44,7 +44,7 @@ const DetailFormCard = () => {
           <CardTitle className=" text-3xl">
             <Input ref={titleRef} defaultValue={title} />
           </CardTitle>
-          <p className="w-full flex justify-end">작성자: {author}</p>
+          <p className="w-full flex justify-end">작성자: {author.name}</p>
         </CardHeader>
         <CardContent className="w-full">
           <Textarea ref={contentRef} defaultValue={content} />

--- a/src/pages/Write/components/DetailFormCard.tsx
+++ b/src/pages/Write/components/DetailFormCard.tsx
@@ -31,7 +31,6 @@ const DetailFormCard = () => {
     updateThread({
       title: titleRef.current.value,
       content: contentRef.current.value,
-      author,
     });
   };
 

--- a/src/pages/Write/index.tsx
+++ b/src/pages/Write/index.tsx
@@ -1,10 +1,10 @@
-import Header, { HeaderHome } from "@/components/ui/header";
+import Header, { HeaderHome, HeaderProfile } from "@/components/ui/header";
 import DetailFormCard from "@/pages/Write/components/DetailFormCard";
 
 const WritePage = () => {
   return (
     <>
-      <Header left={<HeaderHome />} />
+      <Header left={<HeaderHome />} right={<HeaderProfile />} />
       <div className="flex justify-center min-w-96 min-h-96 p-8 gap-4">
         <DetailFormCard />
       </div>

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,8 @@
+declare global {
+  interface Window {
+    Android?: {
+      saveString?: (key: string, value: string) => void;
+      getString?: (key: string) => string;
+    };
+  }
+}


### PR DESCRIPTION
## 작업내용
### signin, signup
회원가입과, 로그인 페이지를 추가했습니다.
![image](https://github.com/user-attachments/assets/590c9961-1176-42ea-a666-b909c8c254a8)
![image](https://github.com/user-attachments/assets/a82ff0e5-8dcb-468a-b455-1ae337e85877)


### profile컴포넌트 (signout)
헤더 컴포넌트에 signout 버튼을 추가했습니다.
![image](https://github.com/user-attachments/assets/d4eaab27-b5bd-4823-9cf0-a8d2689677f6)


### 상세 게시글 페이지에 수정 삭제 dialog를 분리
상세 게시글 페이지에서 수정, 삭제 버튼 을 가지는 dialog 컴포넌트를 분리했습니다. 

### 인가
#### 내 게시글
![image](https://github.com/user-attachments/assets/0abee849-6475-45a0-be5a-d2780a7f2aff)
### 내 게시글 X
![image](https://github.com/user-attachments/assets/67843283-98cd-4228-9d39-cf413d8d61fd)


### fix
- 잘못 참조된 query key (threads -> thread)로 수정했습니다.
- 게시글이 없을때 빈 화면을 안내문으로 대체 했습니다.
